### PR TITLE
Introduce the LGTM stack as alternative OpenSource analysis tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# OpenTelemetry Demo
+# Grafana OpenTelemetry Demo
 
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/demo-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03B4CWV4DA)
 [![Version](https://img.shields.io/github/v/release/open-telemetry/opentelemetry-demo?color=blueviolet)](https://github.com/open-telemetry/opentelemetry-demo/releases)
 [![Commits](https://img.shields.io/github/commits-since/open-telemetry/opentelemetry-demo/latest?color=ff69b4&include_prereleases)](https://github.com/open-telemetry/opentelemetry-demo/graphs/commit-activity)
 [![Downloads](https://img.shields.io/docker/pulls/otel/demo)](https://hub.docker.com/r/otel/demo)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?color=red)](https://github.com/open-telemetry/opentelemetry-demo/blob/main/LICENSE)
+
+This repository is a fork from the original [OpenTelemetry Demo Application](https://github.com/open-telemetry/opentelemetry-demo)
+and meant to showcase the LGTM stack with OpenTelemetry.
 
 ## Under Construction
 
@@ -46,11 +49,11 @@ cd .\src\adservice\
 
 ### Run Docker Compose
 
-- Start the demo (It can take ~20min the first time the command is executed as
-all the images will be build):
+This demo automatically brings up a Grafana LGTM Stack (Loki, Grafana, Tempo, Mimir)
+via docker-compose:
 
 ```shell
-docker compose up
+docker-compose up
 ```
 
 ### Verify the Webstore & the Telemetry

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,50 @@
+version: '3.9'
+x-default-logging: &logging
+  driver: "json-file"
+  options:
+    max-size: "5m"
+    max-file: "2"
+services:
+  # The OTel Collector, preconfigured for LGTM
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.56.0
+    container_name: otel-col
+    command: [ "--config=/etc/otelcol-config.yml" ]
+    volumes:
+      - ./src/otelcollector/otelcol-config-lgtm.yml:/etc/otelcol-config.yml
+    ports:
+      - "4317"
+      - "4318"
+      - "9464"
+      - "8888:8888"
+    depends_on:
+      - tempo
+      - loki
+      - mimir
+    logging: *logging
+
+  # Grafana Loki stores logs
+  loki:
+    image: grafana/loki:2.6.1
+    command: -config.file=/etc/loki/local-config.yaml
+    logging: *logging
+
+  # Grafana Tempo stores traces
+  tempo:
+    image: grafana/tempo:1.4.1
+    restart: unless-stopped
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./src/tempo/tempo.yaml:/etc/tempo.yaml
+    logging: *logging
+
+  # Grafana Mimir stores metrics
+  mimir:
+    image: ${IMAGE_NAME}:${IMAGE_VERSION}-mimir
+    build:
+      context: src/mimir
+    restart: unless-stopped
+    command: --config.file=/etc/mimir/demo.yaml
+    volumes:
+      - ./src/mimir/mimir.yaml:/etc/mimir/demo.yaml
+    logging: *logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -318,11 +318,13 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:9.0.1
+    image: grafana/grafana:9.0.4
     container_name: grafana
     volumes:
       - ./src/grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./src/grafana/provisioning/:/etc/grafana/provisioning/
+    environment:
+      - GF_FEATURE_TOGGLES_ENABLE=tempoBackendSearch,tempoSearch,tempoServiceGraph
     ports:
       - "${GRAFANA_SERVICE_PORT}:${GRAFANA_SERVICE_PORT}"
     logging: *logging

--- a/src/grafana/provisioning/datasources/default.yaml
+++ b/src/grafana/provisioning/datasources/default.yaml
@@ -5,3 +5,31 @@ datasources:
     type: prometheus
     url: http://prometheus:9090
     editable: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false
+    version: 1
+    uid: loki
+  - name: Mimir
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://mimir:9009/prometheus
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    apiVersion: 1
+    uid: tempo

--- a/src/mimir/Dockerfile
+++ b/src/mimir/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/mimir:r196-0380c6d
+
+RUN mkdir -p {/tmp/mimir/rules,/tmp/mimir/compactor,/tmp/mimir/tsdb,/tmp/mimir/data/tsdb,/tmp/mimir/tsdb-sync}

--- a/src/mimir/mimir.yaml
+++ b/src/mimir/mimir.yaml
@@ -1,0 +1,42 @@
+multitenancy_enabled: false
+
+blocks_storage:
+  backend: filesystem
+  bucket_store:
+    sync_dir: /tmp/mimir/tsdb-sync
+  filesystem:
+    dir: /tmp/mimir/data/tsdb
+  tsdb:
+    dir: /tmp/mimir/tsdb
+
+compactor:
+  data_dir: /tmp/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+distributor:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+
+ingester:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/mimir/rules
+
+server:
+  http_listen_port: 9009
+  log_level: error
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1

--- a/src/otelcollector/otelcol-config-lgtm.yml
+++ b/src/otelcollector/otelcol-config-lgtm.yml
@@ -1,0 +1,68 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+  jaeger:
+    protocols:
+      grpc:
+      thrift_binary:
+      thrift_compact:
+      thrift_http:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "otel-collector"
+          scrape_interval: 5s
+          static_configs:
+            - targets: ["localhost:8888"]
+
+processors:
+  batch:
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  otlphttp/mimir:
+    endpoint: http://mimir:9009/otlp
+    compression: none
+    tls:
+      insecure: true
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+    labels:
+      record:
+        traceID: traceid
+      attributes:
+        container.name: "container_name"
+        k8s.cluster.name: "k8s_cluster_name"
+        severity: "severity"
+      resource:
+        resource.name: "resource_name"
+        severity: "severity"
+  jaeger:
+    endpoint: "jaeger:14250"
+    tls:
+      insecure: true
+  logging:
+  prometheus:
+    endpoint: "otelcol:9464"
+  prometheusremotewrite:
+    endpoint: http://mimir:9009/api/v1/push
+
+service:
+  pipelines:
+    traces:
+      receivers: [jaeger,otlp]
+      processors: [batch]
+      exporters: [logging, otlp/tempo]
+    metrics:
+      receivers: [prometheus,otlp]
+      processors: [batch]
+      exporters: [logging, prometheusremotewrite, otlphttp/mimir]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, loki]

--- a/src/tempo/tempo.yaml
+++ b/src/tempo/tempo.yaml
@@ -1,0 +1,65 @@
+
+
+metrics_generator_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_block_bytes: 100_000_000       # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://mimir:9009/api/v1/push
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    block:
+      bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
+      index_downsample_bytes: 1000     # number of bytes per index record
+      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
+      queue_depth: 10000
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics]
+
+search_enabled: true


### PR DESCRIPTION
## Changes

In addition to the default stores for tracing and metrics, this introduces an alternate
scenario with:

* Grafana Loki as a store for OTel logs
* Grafana Tempo as a datastore for traces
* Grafana Mimir as a datastore for Metrics
* OpenTelemetry Collector Contrib preconfigured for the LGTM stack

This alternate scenario is activated without any changes to the instructions.