### PR TITLE
Untangle HTTP endpoints

### DIFF
--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -14,6 +14,13 @@ exporters:
     endpoint: http://loki:3100/loki/api/v1/push
 
 processors:
+  transform/grafanacloudapm:
+    trace_statements:
+      - context: span
+        statements:
+          - replace_match(attributes["http.target"], "/api/products/*", "/api/products/{productId}")
+          - set(name, Concat([attributes["http.method"], attributes["http.target"]], " ")) where name == "HTTP GET" and attributes["http.target"] != nil
+          - set(name, Concat([attributes["http.method"], attributes["http.target"]], " ")) where name == "HTTP POST" and attributes["http.target"] != nil
   batch:
   spanmetrics:
     metrics_exporter: prometheus
@@ -29,7 +36,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [spanmetrics, servicegraph, batch]
+      processors: [transform/grafanacloudapm, spanmetrics, servicegraph, batch]
       exporters: [otlp]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
Operations of "HTTP GET" and "HTTP POST" are not meaningful

This PR extracts the info so we have distinct endpoints

Before
<img width="736" alt="Bildschirm­foto 2023-01-06 um 15 22 18" src="https://user-images.githubusercontent.com/418970/211031148-c10f310a-1955-4dff-a9d8-e624e97c414b.png">

After
<img width="721" alt="Bildschirm­foto 2023-01-06 um 15 20 40" src="https://user-images.githubusercontent.com/418970/211031165-29a50aec-bef6-41c7-9f25-3ba71b33e356.png">
