### PR TITLE
faro: add-to-cart event update quantity to string

### DIFF
--- a/src/frontend/pages/product/[productId]/index.tsx
+++ b/src/frontend/pages/product/[productId]/index.tsx
@@ -56,7 +56,7 @@ const ProductDetail: NextPage = () => {
   const onAddItem = useCallback(async () => {
     faro.api.pushEvent('add-to-cart', {
       'productId': productId,
-      'quantity': quantity as unknown as string,
+      'quantity': String(quantity),
     });
 
     await addItem({


### PR DESCRIPTION
Event attribute values must be strings. I noticed an unmarshal error in the collector due to quantity being an int. This PR converts the quantity to a string.

Signed-off-by: Robbie Lankford <robert.lankford@grafana.com>

