### PR TITLE
enable-job-instance-attributes

### DIFF
--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -24,11 +24,22 @@ processors:
   attributes:
     actions:
       - action: insert
+        key: service.name
+        from_attribute: container_name
+      - action: insert
+        key: service.instance.id
+        from_attribute: container_id
+      - action: insert
         key: service_name
         from_attribute: container_name
       - action: insert
         key: loki.attribute.labels
         value: service_name
+
+  groupbyattrs:
+    keys:
+      - service.name
+      - service.instance.id
 
   transform/grafanacloudapm:
     trace_statements:
@@ -85,5 +96,5 @@ service:
       exporters: [otlp/tempo]
     logs:
       receivers: [otlp, fluentforward]
-      processors: [transform/fluentd, attributes]
+      processors: [transform/fluentd, attributes, groupbyattrs]
       exporters: [loki]


### PR DESCRIPTION
# Changes

- Added `groupbyattrs` processor to group log records by attributes `service.instance.id` and `service.name`
