### PR TITLE
update Faro dependencies to 1.2.2

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
       version:
         description: The version used when tagging the image
-        default: dev
+        default: 'dev'
         required: false
         type: string
 
@@ -101,23 +101,22 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Check for file changes
+      - name: Check for changes and set push options
         id: check_changes
-        if: ${{ !inputs.push }}
         run: |
           DOCKERFILE_DIR=$(dirname ${{ matrix.file_tag.file }})
           FILES_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- $DOCKERFILE_DIR)
-          if [ -z "$FILES_CHANGED" ]; then
+          FORCE_PUSH=${{ inputs.push }}
+          if [ "$FORCE_PUSH" = true ]; then
+            echo "Force push is enabled, proceeding with build."
+            echo "skip='false'" >> "$GITHUB_OUTPUT"
+          elif [ -z "$FILES_CHANGED" ]; then
             echo "No changes in ${{ matrix.file_tag.context }}, skipping build."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip='true'" >> "$GITHUB_OUTPUT"
           else
             echo "Changes detected in ${{ matrix.file_tag.context }}, proceeding with build."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "skip='false'" >> "$GITHUB_OUTPUT"
           fi
-      - name: Override skip for push
-        if: ${{ inputs.push }}
-        run: echo "skip=false" >> "$GITHUB_OUTPUT"
-        id: override_skip
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -142,7 +141,7 @@ jobs:
             [worker.oci]
             max-parallelism = 2
       - name: Matrix Build and push demo images
-        if: steps.check_changes.outputs.skip == 'false' || steps.override_skip.outputs.skip == 'false'
+        if: steps.check_changes.outputs.skip == 'false'
         uses: docker/build-push-action@v3.3.1
         with:
           context: ${{ matrix.file_tag.context }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/build-images.yml
     with:
       push: false
-      version: dev
+      version: 'dev'
 
   markdownlint:
     runs-on: ubuntu-latest

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.9.0",
-    "@grafana/faro-instrumentation-performance-timeline": "^1.2.1",
-    "@grafana/faro-web-sdk": "^1.2.1",
-    "@grafana/faro-web-tracing": "^1.2.1",
+    "@grafana/faro-instrumentation-performance-timeline": "^1.2.2",
+    "@grafana/faro-web-sdk": "^1.2.2",
+    "@grafana/faro-web-tracing": "^1.2.2",
     "@opentelemetry/api": "1.4.1",
     "@opentelemetry/auto-instrumentations-node": "0.39.1",
     "@opentelemetry/auto-instrumentations-web": "0.33.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.9.0",
-    "@grafana/faro-instrumentation-performance-timeline": "^1.0.5",
-    "@grafana/faro-web-sdk": "^1.0.5",
-    "@grafana/faro-web-tracing": "^1.0.5",
+    "@grafana/faro-instrumentation-performance-timeline": "^1.2.1",
+    "@grafana/faro-web-sdk": "^1.2.1",
+    "@grafana/faro-web-tracing": "^1.2.1",
     "@opentelemetry/api": "1.4.1",
     "@opentelemetry/auto-instrumentations-node": "0.39.1",
     "@opentelemetry/auto-instrumentations-web": "0.33.1",


### PR DESCRIPTION
needed for K6 integration - Faro web SDK 1.2.2 contains features for checking if the browser running is k6browser