### PR TITLE
Add namespace tag to profiler

### DIFF
--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -124,6 +124,14 @@ func initMeterProvider() *sdkmetric.MeterProvider {
 }
 
 func initProfilerProvider() *pyroscope.Profiler {
+	resource := initResource()
+
+	tags := map[string]string{}
+	val, ok := resource.Set().Value("service.namespace")
+	if ok && val.Type() == attribute.STRING {
+		tags["namespace"] = val.AsString()
+	}
+
 	stdruntime.SetMutexProfileFraction(5)
 	stdruntime.SetBlockProfileRate(5)
 
@@ -138,7 +146,7 @@ func initProfilerProvider() *pyroscope.Profiler {
 		BasicAuthUser:     os.Getenv("GRAFANA_PYROSCOPE_AUTH_USER"),
 		BasicAuthPassword: os.Getenv("GRAFANA_PYROSCOPE_AUTH_PASS"),
 		Logger:            log,
-		Tags:              map[string]string{},
+		Tags:              tags,
 		ProfileTypes: []pyroscope.ProfileType{
 			pyroscope.ProfileCPU,
 			pyroscope.ProfileAllocObjects,


### PR DESCRIPTION
While working on https://github.com/grafana/app-observability-plugin/pull/782, I realized we don't have a `namespace` label for the `checkoutservice` profiles.

This PR maps the `service.name` OTEL attribute to `namespace` which is used internally within Pyroscope. Long term, we want to align Pyroscope internal labeling strategies to that of the OTEL attribute specifications. In the interim, this mapping will help unblock feature work of integrating profiling with the App Observability plugin.