### PR TITLE
marco/upgrade faro to v1.4.0

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -8,9 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@grafana/faro-instrumentation-performance-timeline": "^1.0.5",
-        "@grafana/faro-web-sdk": "^1.0.5",
-        "@grafana/faro-web-tracing": "^1.0.5",
+        "@grafana/faro-web-sdk": "^1.4.0",
+        "@grafana/faro-web-tracing": "^1.4.0",
         "@grpc/grpc-js": "1.9.13",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/auto-instrumentations-node": "0.40.2",
@@ -233,48 +232,385 @@
       }
     },
     "node_modules/@grafana/faro-core": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.3.5.tgz",
-      "integrity": "sha512-5DBJDVqzTRh6cHq2usmX1eisyQiJ60gX3TEnRIKMQ3a+uwEDJN5q/Cm4wz3PVk1WH8HimzOPMty3FoFN/zxH9g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.4.0.tgz",
+      "integrity": "sha512-YXFk3KP8spP4lmFmjtXt1mEhWA0tSa8xAe3YHAwD2v21EOeOaqWt9qAs1ZQ4L8QrHUXgtIKNDnzAydc9vFZT+Q==",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/otlp-transformer": "^0.45.1",
-        "murmurhash-js": "^1.0.0"
+        "@opentelemetry/otlp-transformer": "^0.48.0"
       }
     },
-    "node_modules/@grafana/faro-instrumentation-performance-timeline": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-instrumentation-performance-timeline/-/faro-instrumentation-performance-timeline-1.3.5.tgz",
-      "integrity": "sha512-qGcV3/K8j6BwfnoK5xEFRvt8TOapdMxmhz8soLPeV9BbdKM9uX2tzWh967eygQRInWl5JjHu+Bm56IdxLfW/mg=="
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/api-logs": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.48.0.tgz",
+      "integrity": "sha512-1/aMiU4Eqo3Zzpfwu51uXssp5pzvHFObk8S9pKAiXb1ne8pvg1qxBQitYL1XUiAMEXFzgjaidYG2V6624DRhhw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/core": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.48.0.tgz",
+      "integrity": "sha512-yuoS4cUumaTK/hhxW3JUy3wl2U4keMo01cFDrUOmjloAdSSXvv1zyQ920IIH4lymp5Xd21Dj2/jq2LOro56TJg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/resources": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
+      "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.48.0.tgz",
+      "integrity": "sha512-lRcA5/qkSJuSh4ItWCddhdn/nNbVvnzM+cm9Fg1xpZUeTeozjJDBcHnmeKoOaWRnrGYBdz6UTY6bynZR9aBeAA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.21.0.tgz",
+      "integrity": "sha512-on1jTzIHc5DyWhRP+xpf+zrgrREXcHBH4EDAfaB5mIG7TWpKxNXooQ1JCylaPsswZUv4wGnVTinr4HrBdGARAQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-core/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
+      "integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
     },
     "node_modules/@grafana/faro-web-sdk": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.3.5.tgz",
-      "integrity": "sha512-yIHLUnunmVvZr4dTMmk6Z2KpfF3HFmDI0YFWQFoQOP6vItHi/kXj9jFV92f0FuEjSaGwq46P9EJclpksL1tZAQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.4.0.tgz",
+      "integrity": "sha512-LybshByhcz70Rx8qJpaCP7lOK0UHSpklosnswkI2zDAlfTggCTpx/WtYU0kjRd4piLJO6joRFDiLVA4lzw/37Q==",
       "dependencies": {
-        "@grafana/faro-core": "^1.3.5",
+        "@grafana/faro-core": "^1.4.0",
         "ua-parser-js": "^1.0.32",
         "web-vitals": "^3.1.1"
       }
     },
     "node_modules/@grafana/faro-web-tracing": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.3.5.tgz",
-      "integrity": "sha512-Y8ezwH2FAL2Zd1OPMFE46doRNEeigXPc9iynT6Jks05Fjs10p7rivOu/NHEs6II4bQ0lYMPzGkVOUNhkQoOqXQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.4.0.tgz",
+      "integrity": "sha512-k0J/vqhBpn+OCrqvpQo1K4nFaIl+WmJfwVAeRZmo1vljOiJHVRcQY6Lj74Q4UsBRl6vr3NAkbgRz2kU7yEG6hQ==",
       "dependencies": {
-        "@grafana/faro-web-sdk": "^1.3.5",
+        "@grafana/faro-web-sdk": "^1.4.0",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/context-zone": "^1.18.1",
         "@opentelemetry/core": "^1.18.1",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",
-        "@opentelemetry/instrumentation": "^0.45.1",
-        "@opentelemetry/instrumentation-document-load": "^0.34.0",
-        "@opentelemetry/instrumentation-fetch": "^0.45.1",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.45.1",
-        "@opentelemetry/otlp-transformer": "^0.45.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation-document-load": "^0.35.0",
+        "@opentelemetry/instrumentation-fetch": "^0.48.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.48.0",
+        "@opentelemetry/otlp-transformer": "^0.48.0",
         "@opentelemetry/resources": "^1.18.1",
         "@opentelemetry/sdk-trace-web": "^1.18.1",
         "@opentelemetry/semantic-conventions": "^1.18.1"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/api-logs": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.48.0.tgz",
+      "integrity": "sha512-1/aMiU4Eqo3Zzpfwu51uXssp5pzvHFObk8S9pKAiXb1ne8pvg1qxBQitYL1XUiAMEXFzgjaidYG2V6624DRhhw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/core": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.48.0.tgz",
+      "integrity": "sha512-QEZKbfWqXrbKVpr2PHd4KyKI0XVOhUYC+p2RPV8s+2K5QzZBE3+F9WlxxrXDfkrvGmpQAZytBoHQQYA3AGOtpw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.48.0.tgz",
+      "integrity": "sha512-T4LJND+Ugl87GUONoyoQzuV9qCn4BFIPOnCH1biYqdGhc2JahjuLqVD9aefwLzGBW638iLAo88Lh68h2F1FLiA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.48.0.tgz",
+      "integrity": "sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.7.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/instrumentation-document-load": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.35.0.tgz",
+      "integrity": "sha512-U3zQBjbAF0rm7GT7YJ8DPqgiCdBoshmld4c1pZe3tAGAMa5QPIjonIfSMSvJ2XMh6Nvi+8Rfe3XFCe0cuWIjsQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/sdk-trace-base": "^1.0.0",
+        "@opentelemetry/sdk-trace-web": "^1.15.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/instrumentation-fetch": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.48.0.tgz",
+      "integrity": "sha512-y4Zw9VeUUMaowg3aXYZXcaUJQ7IKfpR6sjClrAQOJwWG8LYFpM6NIRSoAeJv/ShfxWWCPWC0P4zgXcKRqpURFQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/instrumentation-xml-http-request": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.48.0.tgz",
+      "integrity": "sha512-YJ9d1sR28hcEVtP4/tHtPX5Hhu0w2LsAMp3M+75YGTHkkunsN8PwcY/1FcSHUP9xwy7Z2myQvT7fTpL3g4tn4A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.48.0.tgz",
+      "integrity": "sha512-yuoS4cUumaTK/hhxW3JUy3wl2U4keMo01cFDrUOmjloAdSSXvv1zyQ920IIH4lymp5Xd21Dj2/jq2LOro56TJg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/resources": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
+      "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.48.0.tgz",
+      "integrity": "sha512-lRcA5/qkSJuSh4ItWCddhdn/nNbVvnzM+cm9Fg1xpZUeTeozjJDBcHnmeKoOaWRnrGYBdz6UTY6bynZR9aBeAA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.21.0.tgz",
+      "integrity": "sha512-on1jTzIHc5DyWhRP+xpf+zrgrREXcHBH4EDAfaB5mIG7TWpKxNXooQ1JCylaPsswZUv4wGnVTinr4HrBdGARAQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
+      "integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.21.0.tgz",
+      "integrity": "sha512-MxkmY/UNXkDiZj7JUu5T7wWt8Ai4NJEwSjGoQQ9YLvgLUIivvaIo9Mne+Q+KLOUG2v/uhivz3qzxbCODVa0c1A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing/node_modules/import-in-the-middle": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -1989,9 +2325,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
+      "integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g==",
       "engines": {
         "node": ">=14"
       }
@@ -6066,11 +6402,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/murmurhash-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
-    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -8004,9 +8335,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.0.tgz",
-      "integrity": "sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -12,10 +12,9 @@
     "drone:sign": "drone --server https://drone.grafana.net sign --save grafana/opentelemetry-demo .drone/drone.yml"
   },
   "dependencies": {
+    "@grafana/faro-web-sdk": "^1.4.0",
+    "@grafana/faro-web-tracing": "^1.4.0",
     "@grpc/grpc-js": "1.9.13",
-    "@grafana/faro-instrumentation-performance-timeline": "^1.0.5",
-    "@grafana/faro-web-sdk": "^1.0.5",
-    "@grafana/faro-web-tracing": "^1.0.5",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/auto-instrumentations-node": "0.40.2",
     "@opentelemetry/auto-instrumentations-web": "0.34.0",
@@ -52,8 +51,8 @@
     "@types/node": "20.9.0",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
-    "@types/uuid": "9.0.7",
     "@types/styled-components": "5.1.30",
+    "@types/uuid": "9.0.7",
     "@typescript-eslint/eslint-plugin": "6.10.0",
     "@typescript-eslint/parser": "6.10.0",
     "cypress": "10.11.0",

--- a/src/frontend/utils/telemetry/FaroTracer.ts
+++ b/src/frontend/utils/telemetry/FaroTracer.ts
@@ -5,7 +5,6 @@ import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-docu
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
-import { PerformanceTimelineInstrumentation } from '@grafana/faro-instrumentation-performance-timeline';
 
 const { NEXT_PUBLIC_OTEL_SERVICE_NAME = '', NEXT_GRAFANA_FARO_ENDPOINT = '' } =
   typeof window !== 'undefined' ? window.ENV : {};
@@ -26,8 +25,6 @@ const Faro = async (collectorString: string) => {
       instrumentations: [
         // Mandatory, overwriting the instrumentations array would cause the default instrumentations to be omitted
         ...getWebInstrumentations(),
-
-        new PerformanceTimelineInstrumentation(),
 
         // Mandatory, initialization of the tracing package
         new TracingInstrumentation({


### PR DESCRIPTION
# Changes

* Upgrade Faro to v1.4.0
* remove experimental `faro-instrumentation-performance-timeline`. It was only used to track `navigation` and `resource` timings which is now built into Faro. 

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
